### PR TITLE
Cross-build for arm64

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,9 +22,9 @@ jobs:
         go-version: ${{ matrix.go }}
     - name: test go ${{ matrix.go }}
       run: |
-        curl -sSLO https://github.com/goreleaser/nfpm/releases/download/v0.11.0/nfpm_0.11.0_Linux_x86_64.tar.gz
+        curl -sSLO https://github.com/goreleaser/nfpm/releases/download/v2.11.3/nfpm_2.11.3_Linux_x86_64.tar.gz
         mkdir bin
-        tar xfz nfpm_0.11.0_Linux_x86_64.tar.gz -C bin
+        tar xfz nfpm_2.11.3_Linux_x86_64.tar.gz -C bin
         export PATH=./bin:$PATH
         make
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-apt-s3
-*.deb
+apt-s3_*

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,5 +1,5 @@
 name: "apt-s3"
-arch: "amd64"
+arch: "${ARCH}"
 platform: "linux"
 version: "${VERSION}"
 section: "default"

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -18,7 +18,11 @@ description: |
   apt transport method for repositories hosted in S3.
 homepage: "https://github.com/rbayerl/apt-s3"
 license: "Apache-2.0"
-bindir: "/usr/lib/apt/methods"
-files:
-  ./apt-s3: "/usr/lib/apt/methods/s3"
-  ./LICENSE: "/usr/share/doc/apt-s3/copyright"
+contents:
+  - src: apt-s3
+    dst: /usr/local/bin/apt-s3
+  - src: /usr/local/bin/apt-s3
+    dst: /usr/lib/apt/methods/s3
+    type: symlink
+  - src: LICENSE
+    dst: /usr/share/doc/apt-s3/copyright


### PR DESCRIPTION
- Bump nfpm to 2.11.3
  - Environment variable expansion for the `arch` config key only works from 2.4.0 (https://github.com/goreleaser/nfpm/commit/41077943bd4e6cae828ed28a6adfecf178e79109)
- Tweak the installation slightly
  - Copy binary to `/usr/local/bin/apt-s3`
  - Symlink `/usr/lib/apt/methods/s3` to `/usr/local/bin/apt-s3`
- Add cross-build for arm64
  - nfpm does not support environment variable expansion in the `content` config key (https://github.com/goreleaser/nfpm/pull/405), use a workaround.
  - Fix the curl command used to upload assets, the [API docs](https://docs.github.com/en/rest/reference/releases#upload-a-release-asset) state that the data should be sent as-is.