### PR TITLE
Support bucket names with dots

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To download a file using `apt-s3` simply use the `-download` flag. Run `apt-s3 -
 export BUCKET_NAME=my-s3-bucket
 export BUCKET_REGION=us-east-1
 
-apt-s3 -download s3:/${BUCKET_NAME}.s3-${BUCKET_REGION}.amazonaws.com/file -path /tmp/file
+apt-s3 -download s3://${BUCKET_NAME}.s3-${BUCKET_REGION}.amazonaws.com/file -path /tmp/file
 ```
 
 ## Building

--- a/downloader/downloader_test.go
+++ b/downloader/downloader_test.go
@@ -24,6 +24,13 @@ func TestParseURI(t *testing.T) {
 			key:      "path/to/file",
 			filename: "file",
 		},
+		{
+			uri:      "s3://my.bucket.s3.amazonaws.com/path/to/file",
+			bucket:   "my.bucket",
+			region:   "us-east-1",
+			key:      "path/to/file",
+			filename: "file",
+		},
 	}
 
 	d := &Downloader{}

--- a/main.go
+++ b/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/abrener5735/apt-s3/downloader"
 	"log"
 	"os"
-	"regexp"
 	"runtime"
 
 	"github.com/zendesk/apt-s3/method"
@@ -29,16 +29,16 @@ func main() {
 		os.Exit(0)
 		// Called outside of apt to download a file
 	} else if *downloadUri != "" {
-		if match, _ := regexp.MatchString("s3://.*\\.s3.*\\.amazonaws\\.com/.*", *downloadUri); !match {
+		if !downloader.URIRegex.MatchString(*downloadUri) {
 			log.Fatalf("Incorrect bucket format.\nExpected: s3://<bucket>.s3-<region>.amazonaws.com/path/to/file\n")
-		} else {
-			filename, err := m.Downloader.DownloadFile(*downloadUri, *downloadPath)
-			if err != nil {
-				log.Fatal(err)
-			}
-			fmt.Printf("Downloaded %s\n", filename)
-			os.Exit(0)
 		}
+
+		filename, err := m.Downloader.DownloadFile(*downloadUri, *downloadPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Downloaded %s\n", filename)
+		os.Exit(0)
 	} else {
 		m.Start()
 	}


### PR DESCRIPTION
Changed parsing of URI to use regular expressions so we can easily get the bucket name even if it has dots in the name.